### PR TITLE
fix: await closeIssues async operations

### DIFF
--- a/src/endpoint/closeIssues.ts
+++ b/src/endpoint/closeIssues.ts
@@ -61,22 +61,24 @@ export const closeIssues = async (req: Request, res: Response) => {
           (i) => i.owner === installation.account!.login
         );
 
-        issues.forEach(async ({ owner, repo, issue_number }) => {
-          // Close issues
-          await closeAndComment(octokitInstallation, {
-            owner,
-            repo,
-            issue_number: issue_number[0]!
-          });
-
-          // Close PRs if there are any
-          if (issue_number[1])
+        await Promise.all(
+          issues.map(async ({ owner, repo, issue_number }) => {
+            // Close issues
             await closeAndComment(octokitInstallation, {
               owner,
               repo,
-              issue_number: issue_number[1]
+              issue_number: issue_number[0]!
             });
-        });
+
+            // Close PRs if there are any
+            if (issue_number[1])
+              await closeAndComment(octokitInstallation, {
+                owner,
+                repo,
+                issue_number: issue_number[1]
+              });
+          })
+        );
       }
     });
 


### PR DESCRIPTION
This fixes a race condition in the closeIssues endpoint.

### Problem
`issues.forEach(async ...)` was used without awaiting completion, so the endpoint could return before all issue/PR close + comment operations finished.

### Fix
- Replace `forEach(async ...)` with `await Promise.all(issues.map(async ...))`
- Ensures all close/comment calls complete before responding.

Fixes #47
/claim #47
